### PR TITLE
Refactor import paths in AdminProducts and ProductForm 

### DIFF
--- a/frontend/src/components/admin/AdminProducts.tsx
+++ b/frontend/src/components/admin/AdminProducts.tsx
@@ -12,7 +12,7 @@ import { useToast } from '@/hooks/use-toast';
 import { products } from '@/lib/data';
 import { Product } from '@/types';
 import { useNavigate } from 'react-router-dom';
-import { DeleteProductDialog } from 'src/components/admin/DeleteProductDialog';
+import { DeleteProductDialog } from '@/components/admin/DeleteProductDialog';
 
 export function AdminProducts() {
   const [productList, setProductList] = useState<Product[]>(products);

--- a/frontend/src/components/admin/ProductForm.tsx
+++ b/frontend/src/components/admin/ProductForm.tsx
@@ -20,7 +20,7 @@ import {
 } from '@/components/ui/select';
 import { Textarea } from '@/components/ui/textarea';
 import { Product } from '@/types';
-import { ImageUpload } from 'src/components/admin/ImageUpload';
+import { ImageUpload } from '@/components/admin/ImageUpload';
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 

--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -1,10 +1,10 @@
 import { Suspense } from 'react';
 import { useRoutes } from 'react-router-dom';
-import { mainRoutes } from 'src/routes/sections/MainRoutes';
-import { authRoutes } from 'src/routes/sections/AuthRoutes';
-import { userRoutes } from 'src/routes/sections/UserRoutes';
-import { adminRoutes } from 'src/routes/sections/AdminRoutes';
-import { checkoutRoutes } from 'src/routes/sections/CheckoutRoutes';
+import { mainRoutes } from '@/routes/sections/MainRoutes';
+import { authRoutes } from '@/routes/sections/AuthRoutes';
+import { userRoutes } from '@/routes/sections/UserRoutes';
+import { adminRoutes } from '@/routes/sections/AdminRoutes';
+import { checkoutRoutes } from '@/routes/sections/CheckoutRoutes';
 import LoadingScreen from '@/components/LoadingScreen';
 
 export default function Router() {


### PR DESCRIPTION
Refactor import paths in AdminProducts and ProductForm  components for consistency

- Updated import statements in AdminProducts.tsx and ProductForm.tsx to use absolute paths instead of relative paths, improving code readability and maintainability.
- Ensured consistent import structure across the application by aligning with the established path conventions.